### PR TITLE
feat(v1alpha2): add memory, skills, graphs, attestations

### DIFF
--- a/AASU_White_Paper_Consolidated_v2_2.md
+++ b/AASU_White_Paper_Consolidated_v2_2.md
@@ -414,8 +414,9 @@ For operational governance in regulated environments, this implementation profil
 - Attach model inventory and supply-chain evidence through **AIBOM** and **attestation bundles**.
 
 **Required relationship controls (production profile):**
-- Every AASU references exactly one short-term memory profile.
-- Every production AASU references exactly one long-term memory profile.
+- AASUs MAY omit memory relationships.
+- If long-term memory is configured, short-term memory is mandatory.
+- Memory-enabled production AASUs reference exactly one long-term memory profile.
 - If context graph profile is used, a knowledge graph reference is mandatory.
 - Production AASUs require attestation linkage and model AIBOM linkage.
 

--- a/AASU_White_Paper_Consolidated_v2_2.md
+++ b/AASU_White_Paper_Consolidated_v2_2.md
@@ -7,6 +7,7 @@
 **Document ID:** AASU-WP-2.2-CONSOLIDATED  
 **Version:** 2.2 (Consolidated from v1.0, v1.2, and v2.2)  
 **Date:** 2026-02-23  
+**Implementation Revision Note:** 2026-02-28 (v1alpha2 registry/governance extensions)  
 **Intended Audience:** CISO \| AI Security Engineering \| Red Team \| AppSec \| ML Platform \| Risk & GRC \| Enterprise Architecture \| Audit/Regulators  
 **Classification:** Public / External Distribution Ready
 
@@ -27,7 +28,7 @@ This paper formalizes a security abstraction for repeatable testing and governan
 
 > **Atomic AI Security Unit (AASU)** — the smallest configuration-bound AI system instance that must be treated as a single unit for security testing, red teaming, and audit validation.
 
-It further defines architecture-aware testing patterns, a three-layer validation methodology (unit → orchestration → attack-graph), and mappings to common AI security taxonomies (OWASP and MITRE ATLAS).
+It further defines architecture-aware testing patterns, a three-layer validation methodology (unit → orchestration → attack-graph), mappings to common AI security taxonomies (OWASP and MITRE ATLAS), and implementation extensions for skills, memory, graph context, AIBOM, and attestations.
 
 ---
 
@@ -371,6 +372,43 @@ Each AASU should maintain, at minimum:
 - Traceable certification statements tied to specific AASU IDs
 - Risk acceptance tied to explicit configuration snapshots (not “the chatbot in general”)
 
+### 6.3 Implementation Profile Update (2026-02-28): Skills, Memory, Graph Context, AIBOM, and Attestations
+
+For operational governance in regulated environments, this implementation profile adds first-class assets and relationship controls while preserving the core AASU tuple `(P,M,R,T,K)`.
+
+**Design principles:**
+- Keep AASU core unchanged for conceptual stability.
+- Treat skills as **separate assets**, not inline prompt/memory text.
+- Split memory into distinct **short-term** and **long-term** profiles.
+- Distinguish durable **knowledge graph** from runtime **context graph profile**.
+- Attach model inventory and supply-chain evidence through **AIBOM** and **attestation bundles**.
+
+**Required relationship controls (production profile):**
+- Every AASU references exactly one short-term memory profile.
+- Every production AASU references exactly one long-term memory profile.
+- If context graph profile is used, a knowledge graph reference is mandatory.
+- Production AASUs require attestation linkage and model AIBOM linkage.
+
+**Representative CI classes:**
+- `skill_package`
+- `memory_short_term_profile`
+- `memory_long_term_profile`
+- `knowledge_graph`
+- `context_graph_profile`
+- `aibom_document`
+- `attestation_bundle`
+
+**Representative relationships:**
+- `uses_skill`
+- `uses_short_term_memory`
+- `uses_long_term_memory`
+- `uses_knowledge_graph`
+- `uses_context_graph_profile`
+- `context_graph_derived_from`
+- `stores_memory_in`
+- `indexes_from_corpus`
+- `attests`
+
 ---
 
 ## 7. Standards and Technique Alignment (OWASP + MITRE ATLAS)
@@ -416,7 +454,7 @@ Taxonomies evolve. The mappings below reflect the referenced versions used in th
 | ASI03 | Identity & Privilege Abuse | T |
 | ASI04 | Agentic Supply Chain | MCP / tool ecosystem |
 | ASI05 | Unexpected Code Execution | Tool runtime |
-| ASI06 | Memory Poisoning | R |
+| ASI06 | Memory Poisoning | Short-term/Long-term Memory Profiles, Context Graph |
 | ASI07 | Inter-Agent Insecurity | Routing |
 | ASI08 | Cascading Failures | Sequential chains |
 | ASI09 | Human-Agent Trust Exploitation | UX |
@@ -444,6 +482,8 @@ Taxonomies evolve. The mappings below reflect the referenced versions used in th
 **AASU = (P, M, R, T, K)**
 
 **AI System = Directed Graph of AASUs**
+
+**Governance Extension Assets = {Skills, Short-Term Memory, Long-Term Memory, Knowledge Graph, Context Graph Profile, AIBOM, Attestations}**
 
 **Security Risk = f(Configuration, Topology, Privilege Edges, Routing Logic)**
 

--- a/AASU_White_Paper_Consolidated_v2_2.md
+++ b/AASU_White_Paper_Consolidated_v2_2.md
@@ -81,16 +81,30 @@ flowchart TB
   A --> K
   A -->|certify against| ID
 
-  P --> Pdetail["System/developer prompts<br/>Prompt hierarchy<br/>Routing prompts"]:::detail
-  M --> Mdetail["Provider + model version<br/>Decoding params (temp, top_p)<br/>Max tokens"]:::detail
-  R --> Rdetail["Corpus/indices IDs<br/>Chunking + top-k<br/>Filters/thresholds"]:::detail
-  T --> Tdetail["Tool schemas<br/>Permissions/allowlists<br/>Execution environment"]:::detail
-  K --> Kdetail["Rate limits/timeouts<br/>Context limits<br/>Safety/guardrail enforcement"]:::detail
+  subgraph G["Governance Extension Assets (v1alpha2)"]
+    S["Skill package"]:::ext
+    STM["Short-term memory profile"]:::ext
+    LTM["Long-term memory profile"]:::ext
+    KG["Knowledge graph"]:::ext
+    CG["Context graph profile"]:::ext
+    BOM["AIBOM document"]:::ext
+    ATT["Attestation bundle"]:::ext
+  end
+
+  A -->|uses_skill| S
+  A -->|uses_short_term_memory| STM
+  A -->|uses_long_term_memory| LTM
+  A -->|uses_knowledge_graph| KG
+  A -->|uses_context_graph_profile| CG
+  CG -->|context_graph_derived_from| KG
+  BOM -->|attests| M
+  ATT -->|attests| A
+  ATT -->|attests| BOM
 
   classDef aasu fill:#0b7285,stroke:#083344,color:#ffffff;
   classDef id fill:#fff3bf,stroke:#f08c00,color:#7c2d12;
   classDef comp fill:#e6fcf5,stroke:#0b7285,color:#083344;
-  classDef detail fill:#f8f9fa,stroke:#ced4da,color:#343a40;
+  classDef ext fill:#f1f3f5,stroke:#495057,color:#212529;
 ```
 
 Illustrative runtime flow for a single user request through an AASU:
@@ -98,17 +112,21 @@ Illustrative runtime flow for a single user request through an AASU:
 ```mermaid
 flowchart TB
   IN["User input"] --> PRE["K: Pre-guardrails<br/>(policy checks, limits, allow/deny)"]
-  PRE --> RET{"R enabled?"}
+  PRE --> CG["Context graph assembly<br/>(R + KG + STM/LTM + policy filters)"]
+  CG --> SK{"Skill required?"}
 
-  RET -->|yes| RAG["R: Retrieval<br/>(query → top-k context)"]
-  RET -->|no| ASSEMBLE["P: Prompt assembly<br/>(system + developer + user + context)"]
-  RAG --> ASSEMBLE
+  SK -->|yes| SKILL["Skill package invocation<br/>(procedural memory)"]
+  SK -->|no| ASSEMBLE["P: Prompt assembly<br/>(system + developer + user + context graph)"]
+  SKILL --> ASSEMBLE
 
   ASSEMBLE --> CALL["M: Model call<br/>(model + decoding params)"]
   CALL --> TOOL{"Tool call requested?"}
 
   TOOL -->|yes| EXEC["T: Tool / MCP execution<br/>(permissions + sandbox)"]
-  EXEC --> ASSEMBLE
+  EXEC --> MEM{"Persist to long-term memory?"}
+  MEM -->|yes| LTMW["LTM write<br/>(consent + retention policy)"]
+  MEM -->|no| ASSEMBLE
+  LTMW --> ASSEMBLE
 
   TOOL -->|no| POST["K: Post-guardrails<br/>(output filtering + safe handling)"]
   POST --> OUT["Response"]
@@ -262,7 +280,16 @@ flowchart LR
     ORCH -->|TB3| TOOL[Tool / MCP runtime]
     TOOL --> SYS[(Enterprise systems)]
 
-    ORCH --> MEM[Session memory / state]
+    ORCH --> STM[Short-term memory profile]
+    ORCH --> LTM[Long-term memory profile]
+    STM --> MSTORE[(Memory store)]
+    LTM --> MSTORE
+    ORCH --> KG[Knowledge graph]
+    ORCH --> CG[Context graph profile]
+    CG --> KG
+    ORCH --> SK[Skill package registry]
+    ORCH --> BOM[AIBOM docs]
+    ORCH --> ATT[Attestation bundle]
     ORCH --> LOG[Audit logs / telemetry]
 
     ORCH --> A1[AASU-1]
@@ -337,9 +364,12 @@ Test the full directed graph as an attack surface:
 ```mermaid
 flowchart LR
   DEV["Define / update AASU config<br/>(P, M, R, T, K)"] --> MAN["Generate manifest<br/>(versioned snapshot)"]
-  MAN --> HASH["Compute AASU ID<br/>(configuration hash)"]
+  MAN --> EXT["Bind extension assets<br/>(skills, STM/LTM, KG/CG)"]
+  EXT --> HASH["Compute AASU ID<br/>(configuration hash)"]
+  HASH --> BOM["Generate/update AIBOM"]
+  BOM --> ATT["Create signed attestation bundle"]
 
-  HASH --> T1["Layer 1 tests<br/>(AASU-level)"]
+  ATT --> T1["Layer 1 tests<br/>(AASU-level)"]
   T1 --> T2["Layer 2 tests<br/>(orchestration)"]
   T2 --> T3["Layer 3 tests<br/>(attack-graph)"]
 
@@ -408,6 +438,21 @@ For operational governance in regulated environments, this implementation profil
 - `stores_memory_in`
 - `indexes_from_corpus`
 - `attests`
+
+```mermaid
+flowchart LR
+  AASU["ci:aasu:*"] -->|uses_skill| SK["ci:skill_package:*"]
+  AASU -->|uses_short_term_memory| STM["ci:memory_short_term_profile:*"]
+  AASU -->|uses_long_term_memory| LTM["ci:memory_long_term_profile:*"]
+  AASU -->|uses_knowledge_graph| KG["ci:knowledge_graph:*"]
+  AASU -->|uses_context_graph_profile| CG["ci:context_graph_profile:*"]
+  CG -->|context_graph_derived_from| KG
+  STM -->|stores_memory_in| STORE["ci:store:memory:*"]
+  LTM -->|stores_memory_in| STORE
+  AIBOM["ci:aibom_document:*"] -->|attests| MODEL["ci:model:*"]
+  ATT["ci:attestation_bundle:*"] -->|attests| AASU
+  ATT -->|attests| AIBOM
+```
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,8 @@ All notable changes to this project will be documented in this file.
 - Expand README with AASU decomposition and architecture patterns.
 - Deduplicate documentation and archive older white papers.
 - Add README badges and tidy arXiv paper folder docs/ignores.
-
+- Add v1alpha2-style registry types for skills, memory profiles, graph profiles, AIBOM, and attestations.
+- Add example manifests and relationships for short-term/long-term memory and skill governance.
+- Extend validation invariants for AASU memory and context-graph linkage.
+- Add CLI commands: `policy-check`, `memory-audit`, and `attest-verify`.
+- Update whitepaper/docs narrative with 2026-02-28 implementation profile extensions (skills, memory, graph context, AIBOM, attestations).

--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ Related governance controls are modeled as separate CIs and relationships:
 - knowledge graph and context graph profile (`uses_knowledge_graph`, `uses_context_graph_profile`)
 - attestations (`attests`)
 
+```mermaid
+flowchart LR
+  AASU["AASU (P,M,R,T,K)"] -->|uses_skill| SK["Skill package"]
+  AASU -->|uses_short_term_memory| STM["Short-term memory profile"]
+  AASU -->|uses_long_term_memory| LTM["Long-term memory profile"]
+  AASU -->|uses_knowledge_graph| KG["Knowledge graph"]
+  AASU -->|uses_context_graph_profile| CG["Context graph profile"]
+  CG -->|context_graph_derived_from| KG
+  AIBOM["AIBOM document"] -->|attests| MODEL["Model CI"]
+  ATT["Attestation bundle"] -->|attests| AASU
+  ATT -->|attests| AIBOM
+```
+
 ## Architecture patterns (chains and graphs)
 Modern AI systems are composed of multiple AASUs, typically in these patterns:
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The core AASU abstraction remains unchanged: `(P,M,R,T,K)`. These extensions are
 - Protocol: `docs/protocol.md`
 - Registry & tooling: `docs/registry.md`
 - GitHub Pages site entry: `docs/index.md`
-- TODOs / roadmap: `TODO.md`
-- Roadmap: `ROADMAP.md`
+- Public roadmap: `ROADMAP.md`
+- Implementation backlog (working TODOs): `TODO.md`
 
 ## AASU unit decomposition
 An Atomic AI Security Unit is a **configuration-bound** unit:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ This repository provides:
 - A Git-native CMDB-as-code protocol for asset mapping and audit-ready governance
 - A reference registry + CLI tooling for GitHub PR workflows (add-on)
 
+## v1alpha2 governance extensions
+This repo now includes first-class registry support for:
+- **Skills as separate assets** (`spec.type: skill_package`)
+- **Short-term memory profiles** (`spec.type: memory_short_term_profile`)
+- **Long-term memory profiles** (`spec.type: memory_long_term_profile`)
+- **Knowledge/context graph profiles** (`knowledge_graph`, `context_graph_profile`)
+- **AIBOM and attestation assets** (`aibom_document`, `attestation_bundle`)
+
+The core AASU abstraction remains unchanged: `(P,M,R,T,K)`. These extensions are linked through relationships for governance and impact analysis.
+
 ## Quick links
 - Protocol: `docs/protocol.md`
 - Registry & tooling: `docs/registry.md`
@@ -28,6 +38,13 @@ An Atomic AI Security Unit is a **configuration-bound** unit:
 - **K**: Runtime constraints
 
 Any change to **P/M/R/T/K** creates a new AASU and requires re‑validation.
+
+Related governance controls are modeled as separate CIs and relationships:
+- skills (`uses_skill`)
+- short-term memory (`uses_short_term_memory`)
+- long-term memory (`uses_long_term_memory`)
+- knowledge graph and context graph profile (`uses_knowledge_graph`, `uses_context_graph_profile`)
+- attestations (`attests`)
 
 ## Architecture patterns (chains and graphs)
 Modern AI systems are composed of multiple AASUs, typically in these patterns:
@@ -104,6 +121,9 @@ arxiv_paper/     LaTeX source for submission-style paper
 ```bash
 python3 tools/aasu_registry.py validate
 python3 tools/aasu_registry.py fingerprint --all --write
+python3 tools/aasu_registry.py policy-check
+python3 tools/aasu_registry.py memory-audit --strict
+python3 tools/aasu_registry.py attest-verify
 ```
 
 ## Contributing
@@ -114,4 +134,3 @@ See `SECURITY.md` for reporting guidelines.
 
 ## License
 Apache-2.0. See `LICENSE`.
-

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,13 +3,12 @@
 This roadmap is derived from `TODO.md` and reflects planned updates.
 
 ## Near-term
-- Add skills and memory capabilities
+- Operationalize skills as separate assets and memory as short-term/long-term profiles across case-study topologies
 - Detail examples from use cases
-- Do deeper mappings with OWASP, NIST, MITRE, and other standards
+- Do deeper mappings with OWASP, NIST, MITRE, and other standards (including memory and graph-context controls)
 
 ## Mid-term
 - Full alignment and usage with configuration management systems (e.g., CMDB)
 
 ## Longer-term
 - Create detailed case studies
-

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,7 @@
 # TODO
 
-- Add skills and memory capabilities
+- Operationalize skills as separate assets and memory as short-term/long-term profiles in case-study deployments
 - Detail examples from use cases
-- Do deeper mappings with OWASP, NIST, MITRE, and other standards
+- Do deeper mappings with OWASP, NIST, MITRE, and other standards (including memory and graph-context controls)
 - Full alignment and usage with configuration management systems (e.g., CMDB)
 - Create detailed case studies
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,7 @@ title: Atomic AI Security Unit (AASU)
 
 **AASU = (P, M, R, T, K)**  
 Prompt package, Model instance & parameters, Retrieval configuration, Tool/MCP configuration, Runtime constraints.
-This site provides a landing page for the AASU project.
-- A reference registry + CLI tooling for GitHub PR workflows
+This site provides a landing page for the AASU project, including a reference registry and CLI tooling for GitHub PR workflows.
 
 ## Quick links
 - Repository overview: [`README.md`](../README.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,8 +15,8 @@ This site provides a landing page for the AASU project.
 - White paper (HTML): [`paper/main.html`](paper/main.html)
 - White paper (PDF): [`paper/main.pdf`](paper/main.pdf)
 - Consolidated white paper (Markdown): [`../AASU_White_Paper_Consolidated_v2_2.md`](../AASU_White_Paper_Consolidated_v2_2.md)
+- Consolidated white paper implementation update: skills + short/long-term memory + graph context + AIBOM/attestations (2026-02-28)
 - White paper archive: [`whitepapers/index.md`](whitepapers/index.md)
 - Git-CMDB protocol (AGCVCP): [`protocol.md`](protocol.md)
 - Registry + tooling: [`registry.md`](registry.md)
  
-

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -108,6 +108,12 @@ Required minimum fields:
 - `spec.type`
 - `spec.lifecycle`
 
+Recommended CI classes for regulated agentic systems:
+- Core runtime: `aasu`, `model`, `prompt_package`, `retrieval`, `tool`, `policy`
+- Governance extensions: `skill_package`, `memory_short_term_profile`, `memory_long_term_profile`
+- Graph context: `knowledge_graph`, `context_graph_profile`
+- Supply chain and evidence: `aibom_document`, `attestation_bundle`
+
 ### 4.2 Relationship manifest
 Each relationship is a YAML file with:
 - `kind`: `Relationship`
@@ -115,6 +121,17 @@ Each relationship is a YAML file with:
 - `spec.type`: relationship type
 - `spec.from`: source CI ID
 - `spec.to`: destination CI ID
+
+Recommended relationship types for governance extensions:
+- `uses_skill`
+- `uses_short_term_memory`
+- `uses_long_term_memory`
+- `uses_knowledge_graph`
+- `uses_context_graph_profile`
+- `context_graph_derived_from`
+- `stores_memory_in`
+- `indexes_from_corpus`
+- `attests`
 
 ### 4.3 AASU snapshot & fingerprint (the core AASU binding)
 For CIs where `spec.type: aasu`, the manifest MUST include:
@@ -124,6 +141,11 @@ For CIs where `spec.type: aasu`, the manifest MUST include:
 **Fingerprint rule (v1):**
 - Canonicalize `spec.aasu.snapshot` to JSON with sorted keys
 - Compute `sha256` and store as `sha256:<64-hex>`
+
+Validation invariants for regulated profiles:
+- Every AASU MUST reference exactly one short-term memory profile.
+- Production AASUs MUST reference exactly one long-term memory profile.
+- If an AASU references a context graph profile, it MUST also reference a knowledge graph.
 
 ---
 
@@ -165,4 +187,3 @@ See:
 - Registry + example manifests in `registry/`
 - CLI: `python3 tools/aasu_registry.py validate`
 - GitHub PR validation + impact comments: `.github/workflows/registry-validate.yml`
-

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -143,8 +143,9 @@ For CIs where `spec.type: aasu`, the manifest MUST include:
 - Compute `sha256` and store as `sha256:<64-hex>`
 
 Validation invariants for regulated profiles:
-- Every AASU MUST reference exactly one short-term memory profile.
-- Production AASUs MUST reference exactly one long-term memory profile.
+- AASUs MAY omit memory relationships.
+- If an AASU references long-term memory, it MUST also reference short-term memory.
+- If an AASU enables memory in production, it MUST reference exactly one long-term memory profile.
 - If an AASU references a context graph profile, it MUST also reference a knowledge graph.
 
 ---

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -15,6 +15,12 @@ Validate all manifests (schemas + relationship integrity + AASU fingerprint chec
 python3 tools/aasu_registry.py validate
 ```
 
+Run regulated policy checks (pinning, memory links, attestation linkage):
+
+```bash
+python3 tools/aasu_registry.py policy-check
+```
+
 After editing an AASU snapshot `(P,M,R,T,K)`, update fingerprints and re-validate:
 
 ```bash
@@ -40,8 +46,19 @@ Export registry manifests as JSON (for CMDB sync tooling):
 python3 tools/aasu_registry.py export --pretty --out registry-export.json
 ```
 
+Audit short-term and long-term memory coverage:
+
+```bash
+python3 tools/aasu_registry.py memory-audit --strict
+```
+
+Verify attestation relationships:
+
+```bash
+python3 tools/aasu_registry.py attest-verify
+```
+
 ## GitHub PR workflow (recommended)
 - Require the validation workflow: `.github/workflows/registry-validate.yml`
 - Optionally post an “Impact Report” PR comment (already configured in the workflow)
 - Use `.github/CODEOWNERS.template` (rename/customize) + branch protections for required approvals
-

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -21,6 +21,17 @@ Run regulated policy checks (pinning, memory links, attestation linkage):
 python3 tools/aasu_registry.py policy-check
 ```
 
+To enforce stricter production policy (memory required for all production AASUs):
+
+```bash
+python3 tools/aasu_registry.py policy-check --require-memory-for-prod
+```
+
+Current unpinned version detection flags:
+- moving aliases such as `latest` and `rolling`
+- branch refs such as `main`, `master`, `trunk`, `head`
+- explicit branch references such as `git:branch:*`, `branch:*`, and `refs/heads/*`
+
 After editing an AASU snapshot `(P,M,R,T,K)`, update fingerprints and re-validate:
 
 ```bash

--- a/docs/whitepapers/AASU_White_Paper_Extended_v2_2_Enriched.md
+++ b/docs/whitepapers/AASU_White_Paper_Extended_v2_2_Enriched.md
@@ -9,6 +9,7 @@
 **Document ID:** AASU-WP-2.2\
 **Version:** 2.2 (Highly Enriched Edition)\
 **Date:** 2026-02-23\
+**Implementation Revision Note:** 2026-02-28 (v1alpha2 registry/governance extensions)\
 **Intended Audience:**\
 CISO \| AI Security Engineering \| Red Team \| ML Platform \| Risk & GRC
 \| Enterprise Architecture \| Regulators
@@ -40,6 +41,7 @@ and expands it into:
 -   Governance & compliance model\
 -   Coverage metrics framework\
 -   Enterprise operating model
+-   Skills, short/long-term memory, graph-context, AIBOM and attestation governance profile
 
 ------------------------------------------------------------------------
 
@@ -145,6 +147,17 @@ flowchart TD
 
 The AASU framework enables topology-aware, configuration-bound,
 graph-based assurance for enterprise AI systems.
+
+For operational implementation in regulated environments, the current
+profile adds:
+
+-   Skills as separate `skill_package` assets
+-   Distinct short-term and long-term memory profiles
+-   Knowledge graph (durable) and context graph profile (runtime)
+-   AIBOM and attestation assets linked through relationship controls
+
+These controls preserve the core AASU tuple while materially improving
+change governance, auditability, and policy enforcement.
 
 ------------------------------------------------------------------------
 

--- a/docs/whitepapers/AASU_White_Paper_Extended_v2_2_Enriched.md
+++ b/docs/whitepapers/AASU_White_Paper_Extended_v2_2_Enriched.md
@@ -73,6 +73,27 @@ Any change in P, M, R, T, or K creates a new AASU.
 
 ------------------------------------------------------------------------
 
+## 2.1 Implementation Governance Profile (2026-02-28)
+
+The operational profile keeps `(P,M,R,T,K)` unchanged while modeling
+skills, memory, graph context, and attestations as separate governed
+assets.
+
+``` mermaid
+flowchart LR
+    AASU["AASU (P,M,R,T,K)"] -->|uses_skill| SK["Skill package"]
+    AASU -->|uses_short_term_memory| STM["Short-term memory profile"]
+    AASU -->|uses_long_term_memory| LTM["Long-term memory profile"]
+    AASU -->|uses_knowledge_graph| KG["Knowledge graph"]
+    AASU -->|uses_context_graph_profile| CG["Context graph profile"]
+    CG -->|context_graph_derived_from| KG
+    AIBOM["AIBOM document"] -->|attests| MODEL["Model CI"]
+    ATT["Attestation bundle"] -->|attests| AASU
+    ATT -->|attests| AIBOM
+```
+
+------------------------------------------------------------------------
+
 # 3. Architecture Patterns
 
 ## Sequential Chain

--- a/docs/whitepapers/AASU_White_Paper_Publish_Ready_v1_2.md
+++ b/docs/whitepapers/AASU_White_Paper_Publish_Ready_v1_2.md
@@ -46,6 +46,27 @@ Any change in P, M, R, T, or K creates a new AASU.
 
 ------------------------------------------------------------------------
 
+## 1.2 Implementation Governance Profile (2026-02-28)
+
+The operational profile keeps `(P,M,R,T,K)` unchanged while modeling
+skills, memory, graph context, and attestations as separate governed
+assets.
+
+``` mermaid
+flowchart LR
+    AASU["AASU (P,M,R,T,K)"] -->|uses_skill| SK["Skill package"]
+    AASU -->|uses_short_term_memory| STM["Short-term memory profile"]
+    AASU -->|uses_long_term_memory| LTM["Long-term memory profile"]
+    AASU -->|uses_knowledge_graph| KG["Knowledge graph"]
+    AASU -->|uses_context_graph_profile| CG["Context graph profile"]
+    CG -->|context_graph_derived_from| KG
+    AIBOM["AIBOM document"] -->|attests| MODEL["Model CI"]
+    ATT["Attestation bundle"] -->|attests| AASU
+    ATT -->|attests| AIBOM
+```
+
+------------------------------------------------------------------------
+
 # 2. Architecture Patterns with Mermaid Diagrams
 
 ## 2.1 Single AASU

--- a/docs/whitepapers/index.md
+++ b/docs/whitepapers/index.md
@@ -6,7 +6,7 @@ title: White Papers
 # AASU White Papers
 
 **Canonical (current):**
-- `AASU_White_Paper_Consolidated_v2_2.md` (top-level)
+- `AASU_White_Paper_Consolidated_v2_2.md` (top-level; includes 2026-02-28 implementation profile update for skills, memory, graph context, AIBOM/attestations)
 
 **Archived versions:**
 - `Atomic_AI_Security_Unit_AASU_White_Paper.md` (v1.0)
@@ -14,4 +14,3 @@ title: White Papers
 - `AASU_White_Paper_Extended_v2_2_Enriched.md` (v2.2 enriched)
 
 If you need the publish-ready or enriched technical editions, use the archived versions above.
-

--- a/registry/assets/aasu/example-customer-support-chatbot-prod.yaml
+++ b/registry/assets/aasu/example-customer-support-chatbot-prod.yaml
@@ -22,7 +22,7 @@ spec:
         version: "git:sha:0123456789abcdef"
       M:
         asset: ci:model:provider:openai:gpt-4o
-        version: "provider:rolling"
+        version: "provider:date:2026-02-20"
       R:
         asset: ci:retrieval:index:customer-support-kb:prod:2026-02-01
         version: "index-snapshot:2026-02-01"
@@ -34,7 +34,7 @@ spec:
         version: "policy:v1"
     fingerprint:
       algorithm: sha256
-      value: sha256:3b608048da92f1cb65d6f6f6405fb887c13617a0ce5db0e1c5cbc1dbd11a4b8b
+      value: sha256:9ccacacde716b19a9a56081af87022169f3bf351178b7965f4e4df2d32f97bc6
     certification:
       status: pending
       evidence:

--- a/registry/assets/aibom_document/example-openai-gpt4o-aibom.yaml
+++ b/registry/assets/aibom_document/example-openai-gpt4o-aibom.yaml
@@ -1,0 +1,27 @@
+apiVersion: aasu.ai/v1alpha1
+kind: ConfigurationItem
+metadata:
+  id: ci:aibom_document:model:openai:gpt-4o:2026-02-20
+  name: AIBOM Document (OpenAI GPT-4o / 2026-02-20 profile)
+  owners:
+    - type: team
+      id: ml-platform
+      role: primary
+    - type: team
+      id: appsec
+      role: security
+spec:
+  type: aibom_document
+  lifecycle: active
+  artifacts:
+    - kind: artifact
+      url: artifact:registry/aibom/openai-gpt4o-2026-02-20.cdx.json
+  aibom:
+    format: cyclonedx-mlbom
+    version: "1.7"
+    model_asset: ci:model:provider:openai:gpt-4o
+    parameters_profile:
+      temperature: "0.2"
+      top_p: "0.95"
+      max_tokens: "1024"
+

--- a/registry/assets/attestation_bundle/example-customer-support-aasu-attestations.yaml
+++ b/registry/assets/attestation_bundle/example-customer-support-aasu-attestations.yaml
@@ -1,0 +1,26 @@
+apiVersion: aasu.ai/v1alpha1
+kind: ConfigurationItem
+metadata:
+  id: ci:attestation_bundle:aasu:customer-support-chatbot:prod:2026-02-25
+  name: Attestation Bundle (Customer Support AASU / prod / 2026-02-25)
+  owners:
+    - type: team
+      id: appsec
+      role: primary
+    - type: team
+      id: risk-grc
+      role: governance
+spec:
+  type: attestation_bundle
+  lifecycle: active
+  environment: prod
+  artifacts:
+    - kind: artifact
+      url: artifact:registry/attestations/customer-support-aasu-prod-2026-02-25.intoto.jsonl
+  attestation_bundle:
+    signatures:
+      - sigstore-cosign
+    statement_types:
+      - in-toto
+      - slsa-provenance
+

--- a/registry/assets/context_graph_profile/example-customer-support-context-graph-profile.yaml
+++ b/registry/assets/context_graph_profile/example-customer-support-context-graph-profile.yaml
@@ -1,0 +1,22 @@
+apiVersion: aasu.ai/v1alpha1
+kind: ConfigurationItem
+metadata:
+  id: ci:context_graph_profile:customer-support:prod:v1
+  name: Context Graph Profile (Customer Support / prod) v1
+  owners:
+    - type: team
+      id: product-ai
+      role: primary
+    - type: team
+      id: appsec
+      role: security
+spec:
+  type: context_graph_profile
+  lifecycle: active
+  environment: prod
+  context_graph_profile:
+    assembly_strategy: relevance-and-policy-filtered
+    max_context_nodes: 40
+    max_context_tokens: 12000
+    provenance_required: true
+

--- a/registry/assets/dataset/example-customer-support-kb-corpus.yaml
+++ b/registry/assets/dataset/example-customer-support-kb-corpus.yaml
@@ -1,0 +1,21 @@
+apiVersion: aasu.ai/v1alpha1
+kind: ConfigurationItem
+metadata:
+  id: ci:dataset:customer-support-kb:prod:2026-02-01
+  name: Dataset (Customer Support KB Corpus / prod / 2026-02-01)
+  owners:
+    - type: team
+      id: data-platform
+      role: primary
+spec:
+  type: dataset
+  lifecycle: active
+  environment: prod
+  artifacts:
+    - kind: artifact
+      url: artifact:registry/datasets/customer-support-kb/2026-02-01.tar.zst
+  dataset:
+    data_classification: internal
+    source_systems:
+      - support-kb
+

--- a/registry/assets/knowledge_graph/example-customer-support-knowledge-graph.yaml
+++ b/registry/assets/knowledge_graph/example-customer-support-knowledge-graph.yaml
@@ -1,0 +1,24 @@
+apiVersion: aasu.ai/v1alpha1
+kind: ConfigurationItem
+metadata:
+  id: ci:knowledge_graph:customer-support:prod:v1
+  name: Knowledge Graph (Customer Support / prod) v1
+  owners:
+    - type: team
+      id: data-platform
+      role: primary
+    - type: team
+      id: appsec
+      role: security
+spec:
+  type: knowledge_graph
+  lifecycle: active
+  environment: prod
+  knowledge_graph:
+    snapshot: "kg-snapshot:2026-02-25"
+    provenance_required: true
+    sensitivity_labels:
+      - public
+      - internal
+      - restricted
+

--- a/registry/assets/memory_long_term_profile/example-customer-support-long-term-memory.yaml
+++ b/registry/assets/memory_long_term_profile/example-customer-support-long-term-memory.yaml
@@ -1,0 +1,27 @@
+apiVersion: aasu.ai/v1alpha1
+kind: ConfigurationItem
+metadata:
+  id: ci:memory_long_term_profile:customer-support:tenant:v1
+  name: Long-Term Memory Profile (Customer Support Tenant) v1
+  owners:
+    - type: team
+      id: product-ai
+      role: primary
+    - type: team
+      id: data-platform
+      role: operations
+    - type: team
+      id: appsec
+      role: security
+spec:
+  type: memory_long_term_profile
+  lifecycle: active
+  environment: prod
+  memory:
+    namespace: tenant-and-user
+    retention_days: 365
+    legal_hold_supported: true
+    consent_mode: explicit-opt-in
+    erase_sla_days: 30
+    write_policy: allow-approved-facts-only
+

--- a/registry/assets/memory_short_term_profile/example-customer-support-session-memory.yaml
+++ b/registry/assets/memory_short_term_profile/example-customer-support-session-memory.yaml
@@ -1,0 +1,23 @@
+apiVersion: aasu.ai/v1alpha1
+kind: ConfigurationItem
+metadata:
+  id: ci:memory_short_term_profile:customer-support:session:v1
+  name: Short-Term Memory Profile (Customer Support Session) v1
+  owners:
+    - type: team
+      id: product-ai
+      role: primary
+    - type: team
+      id: appsec
+      role: security
+spec:
+  type: memory_short_term_profile
+  lifecycle: active
+  environment: prod
+  memory:
+    scope: thread
+    max_turns: 20
+    ttl_minutes: 120
+    tool_output_retention: minimal
+    cross_user_isolation: required
+

--- a/registry/assets/skill_package/example-customer-support-triage-skill.yaml
+++ b/registry/assets/skill_package/example-customer-support-triage-skill.yaml
@@ -1,0 +1,29 @@
+apiVersion: aasu.ai/v1alpha1
+kind: ConfigurationItem
+metadata:
+  id: ci:skill_package:customer-support-triage:v1
+  name: Skill Package (Customer Support Triage) v1
+  description: Reusable operational skill package for triage and refunds flows.
+  owners:
+    - type: team
+      id: product-ai
+      role: primary
+    - type: team
+      id: appsec
+      role: security
+spec:
+  type: skill_package
+  lifecycle: active
+  artifacts:
+    - kind: git
+      repo: github.com/acme/customer-support-skills
+      path: skills/customer-support-triage/SKILL.md
+      rev: "git:sha:fedcba9876543210fedcba9876543210fedcba98"
+  skill_package:
+    invocation:
+      implicit: false
+      explicit_only: true
+    declared_tools:
+      - ci:tool:mcp:refunds
+    risk_tier: medium
+

--- a/registry/assets/store/example-memory-store.yaml
+++ b/registry/assets/store/example-memory-store.yaml
@@ -1,0 +1,21 @@
+apiVersion: aasu.ai/v1alpha1
+kind: ConfigurationItem
+metadata:
+  id: ci:store:memory:customer-support-prod
+  name: Memory Store (Customer Support / prod)
+  owners:
+    - type: team
+      id: data-platform
+      role: primary
+    - type: team
+      id: appsec
+      role: security
+spec:
+  type: store
+  lifecycle: active
+  environment: prod
+  store:
+    kind: memory
+    platform: managed
+    encryption_at_rest: true
+

--- a/registry/relationships/example-aasu-uses-context-graph-profile.yaml
+++ b/registry/relationships/example-aasu-uses-context-graph-profile.yaml
@@ -1,0 +1,9 @@
+apiVersion: aasu.ai/v1alpha1
+kind: Relationship
+metadata:
+  id: rel:ci:aasu:customer-support-chatbot:prod:uses_context_graph_profile:customer-support
+spec:
+  type: uses_context_graph_profile
+  from: ci:aasu:customer-support-chatbot:prod
+  to: ci:context_graph_profile:customer-support:prod:v1
+

--- a/registry/relationships/example-aasu-uses-knowledge-graph.yaml
+++ b/registry/relationships/example-aasu-uses-knowledge-graph.yaml
@@ -1,0 +1,9 @@
+apiVersion: aasu.ai/v1alpha1
+kind: Relationship
+metadata:
+  id: rel:ci:aasu:customer-support-chatbot:prod:uses_knowledge_graph:customer-support
+spec:
+  type: uses_knowledge_graph
+  from: ci:aasu:customer-support-chatbot:prod
+  to: ci:knowledge_graph:customer-support:prod:v1
+

--- a/registry/relationships/example-aasu-uses-long-term-memory.yaml
+++ b/registry/relationships/example-aasu-uses-long-term-memory.yaml
@@ -1,0 +1,9 @@
+apiVersion: aasu.ai/v1alpha1
+kind: Relationship
+metadata:
+  id: rel:ci:aasu:customer-support-chatbot:prod:uses_long_term_memory:profile
+spec:
+  type: uses_long_term_memory
+  from: ci:aasu:customer-support-chatbot:prod
+  to: ci:memory_long_term_profile:customer-support:tenant:v1
+

--- a/registry/relationships/example-aasu-uses-short-term-memory.yaml
+++ b/registry/relationships/example-aasu-uses-short-term-memory.yaml
@@ -1,0 +1,9 @@
+apiVersion: aasu.ai/v1alpha1
+kind: Relationship
+metadata:
+  id: rel:ci:aasu:customer-support-chatbot:prod:uses_short_term_memory:profile
+spec:
+  type: uses_short_term_memory
+  from: ci:aasu:customer-support-chatbot:prod
+  to: ci:memory_short_term_profile:customer-support:session:v1
+

--- a/registry/relationships/example-aasu-uses-skill.yaml
+++ b/registry/relationships/example-aasu-uses-skill.yaml
@@ -1,0 +1,9 @@
+apiVersion: aasu.ai/v1alpha1
+kind: Relationship
+metadata:
+  id: rel:ci:aasu:customer-support-chatbot:prod:uses_skill:customer-support-triage
+spec:
+  type: uses_skill
+  from: ci:aasu:customer-support-chatbot:prod
+  to: ci:skill_package:customer-support-triage:v1
+

--- a/registry/relationships/example-aibom-attests-model.yaml
+++ b/registry/relationships/example-aibom-attests-model.yaml
@@ -1,0 +1,9 @@
+apiVersion: aasu.ai/v1alpha1
+kind: Relationship
+metadata:
+  id: rel:ci:aibom_document:model:openai:gpt-4o:2026-02-20:attests:model
+spec:
+  type: attests
+  from: ci:aibom_document:model:openai:gpt-4o:2026-02-20
+  to: ci:model:provider:openai:gpt-4o
+

--- a/registry/relationships/example-attestation-bundle-attests-aasu.yaml
+++ b/registry/relationships/example-attestation-bundle-attests-aasu.yaml
@@ -1,0 +1,9 @@
+apiVersion: aasu.ai/v1alpha1
+kind: Relationship
+metadata:
+  id: rel:ci:attestation_bundle:aasu:customer-support-chatbot:prod:2026-02-25:attests:aasu
+spec:
+  type: attests
+  from: ci:attestation_bundle:aasu:customer-support-chatbot:prod:2026-02-25
+  to: ci:aasu:customer-support-chatbot:prod
+

--- a/registry/relationships/example-attestation-bundle-attests-aibom.yaml
+++ b/registry/relationships/example-attestation-bundle-attests-aibom.yaml
@@ -1,0 +1,9 @@
+apiVersion: aasu.ai/v1alpha1
+kind: Relationship
+metadata:
+  id: rel:ci:attestation_bundle:aasu:customer-support-chatbot:prod:2026-02-25:attests:aibom
+spec:
+  type: attests
+  from: ci:attestation_bundle:aasu:customer-support-chatbot:prod:2026-02-25
+  to: ci:aibom_document:model:openai:gpt-4o:2026-02-20
+

--- a/registry/relationships/example-context-graph-derived-from-knowledge-graph.yaml
+++ b/registry/relationships/example-context-graph-derived-from-knowledge-graph.yaml
@@ -1,0 +1,9 @@
+apiVersion: aasu.ai/v1alpha1
+kind: Relationship
+metadata:
+  id: rel:ci:context_graph_profile:customer-support:prod:v1:context_graph_derived_from:kg
+spec:
+  type: context_graph_derived_from
+  from: ci:context_graph_profile:customer-support:prod:v1
+  to: ci:knowledge_graph:customer-support:prod:v1
+

--- a/registry/relationships/example-long-term-memory-stores-in-memory-store.yaml
+++ b/registry/relationships/example-long-term-memory-stores-in-memory-store.yaml
@@ -1,0 +1,9 @@
+apiVersion: aasu.ai/v1alpha1
+kind: Relationship
+metadata:
+  id: rel:ci:memory_long_term_profile:customer-support:tenant:v1:stores_memory_in:store
+spec:
+  type: stores_memory_in
+  from: ci:memory_long_term_profile:customer-support:tenant:v1
+  to: ci:store:memory:customer-support-prod
+

--- a/registry/relationships/example-retrieval-indexes-from-corpus.yaml
+++ b/registry/relationships/example-retrieval-indexes-from-corpus.yaml
@@ -1,0 +1,9 @@
+apiVersion: aasu.ai/v1alpha1
+kind: Relationship
+metadata:
+  id: rel:ci:retrieval:index:customer-support-kb:prod:2026-02-01:indexes_from_corpus:dataset
+spec:
+  type: indexes_from_corpus
+  from: ci:retrieval:index:customer-support-kb:prod:2026-02-01
+  to: ci:dataset:customer-support-kb:prod:2026-02-01
+

--- a/registry/relationships/example-short-term-memory-stores-in-memory-store.yaml
+++ b/registry/relationships/example-short-term-memory-stores-in-memory-store.yaml
@@ -1,0 +1,9 @@
+apiVersion: aasu.ai/v1alpha1
+kind: Relationship
+metadata:
+  id: rel:ci:memory_short_term_profile:customer-support:session:v1:stores_memory_in:store
+spec:
+  type: stores_memory_in
+  from: ci:memory_short_term_profile:customer-support:session:v1
+  to: ci:store:memory:customer-support-prod
+

--- a/registry/schemas/configuration-item.schema.json
+++ b/registry/schemas/configuration-item.schema.json
@@ -71,7 +71,14 @@
             "policy",
             "service",
             "pipeline",
-            "store"
+            "store",
+            "skill_package",
+            "memory_short_term_profile",
+            "memory_long_term_profile",
+            "knowledge_graph",
+            "context_graph_profile",
+            "aibom_document",
+            "attestation_bundle"
           ]
         },
         "lifecycle": {
@@ -188,4 +195,3 @@
     }
   }
 }
-

--- a/registry/schemas/relationship.schema.json
+++ b/registry/schemas/relationship.schema.json
@@ -33,7 +33,16 @@
             "deployed_on",
             "trains_on",
             "uses_model",
-            "uses_prompt_package"
+            "uses_prompt_package",
+            "uses_skill",
+            "uses_short_term_memory",
+            "uses_long_term_memory",
+            "uses_knowledge_graph",
+            "uses_context_graph_profile",
+            "context_graph_derived_from",
+            "stores_memory_in",
+            "indexes_from_corpus",
+            "attests"
           ]
         },
         "from": {
@@ -48,4 +57,3 @@
     }
   }
 }
-

--- a/tools/aasu_registry.py
+++ b/tools/aasu_registry.py
@@ -81,7 +81,15 @@ def _is_prod_aasu(obj: dict[str, Any]) -> bool:
 
 def _is_unpinned_version(version: str) -> bool:
     value = version.strip().lower()
-    return value in {"provider:rolling", "latest", "main", "master"}
+    if value in {"latest", "rolling", "main", "master", "trunk", "head"}:
+        return True
+    if "refs/heads/" in value:
+        return True
+    if value.startswith("git:branch:") or value.startswith("branch:") or ":branch:" in value:
+        return True
+    if re.search(r"(^|:)(latest|rolling|main|master|trunk|head)$", value):
+        return True
+    return False
 
 
 def _load_assets_and_relationships(
@@ -486,10 +494,23 @@ def cmd_policy_check(args: argparse.Namespace) -> int:
                 findings.append(f"{ci_id}: model '{model_id}' has no incoming attests edge from aibom_document")
 
         outgoing_rels = outgoing.get(ci_id, [])
-        if not any(rel_type == "uses_short_term_memory" for rel_type, _ in outgoing_rels):
-            findings.append(f"{ci_id}: missing uses_short_term_memory relationship")
-        if not any(rel_type == "uses_long_term_memory" for rel_type, _ in outgoing_rels):
-            findings.append(f"{ci_id}: missing uses_long_term_memory relationship")
+        stm_count = sum(1 for rel_type, _ in outgoing_rels if rel_type == "uses_short_term_memory")
+        ltm_count = sum(1 for rel_type, _ in outgoing_rels if rel_type == "uses_long_term_memory")
+        memory_enabled = stm_count > 0 or ltm_count > 0
+        if stm_count > 1:
+            findings.append(f"{ci_id}: multiple uses_short_term_memory relationships ({stm_count})")
+        if ltm_count > 1:
+            findings.append(f"{ci_id}: multiple uses_long_term_memory relationships ({ltm_count})")
+        if ltm_count > 0 and stm_count == 0:
+            findings.append(f"{ci_id}: long-term memory is configured without short-term memory")
+        if memory_enabled and ltm_count != 1:
+            findings.append(
+                f"{ci_id}: memory-enabled production AASU must have exactly one uses_long_term_memory relationship"
+            )
+        if args.require_memory_for_prod and not memory_enabled:
+            findings.append(
+                f"{ci_id}: memory is required for production AASU under --require-memory-for-prod policy"
+            )
 
     if findings:
         print("POLICY CHECK FAILED")
@@ -522,11 +543,17 @@ def cmd_memory_audit(args: argparse.Namespace) -> int:
         print(f"- `{ci_id}`")
         print(f"  - short-term memory profiles: {', '.join(stm) if stm else 'none'}")
         print(f"  - long-term memory profiles: {', '.join(ltm) if ltm else 'none'}")
-
-        if len(stm) != 1:
-            findings.append(f"{ci_id}: expected exactly one short-term memory profile, found {len(stm)}")
-        if _is_prod_aasu(obj) and len(ltm) != 1:
-            findings.append(f"{ci_id}: production AASU expected exactly one long-term memory profile, found {len(ltm)}")
+        memory_enabled = len(stm) > 0 or len(ltm) > 0
+        if len(stm) > 1:
+            findings.append(f"{ci_id}: expected at most one short-term memory profile, found {len(stm)}")
+        if len(ltm) > 1:
+            findings.append(f"{ci_id}: expected at most one long-term memory profile, found {len(ltm)}")
+        if len(ltm) > 0 and len(stm) == 0:
+            findings.append(f"{ci_id}: has long-term memory profile but no short-term memory profile")
+        if _is_prod_aasu(obj) and memory_enabled and len(ltm) != 1:
+            findings.append(
+                f"{ci_id}: memory-enabled production AASU expected exactly one long-term memory profile, found {len(ltm)}"
+            )
 
     for ci_id, obj in sorted(assets_by_id.items()):
         typ = _ci_type(obj)
@@ -865,6 +892,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run policy checks for regulated-ready AASU governance (pinning, memory links, attestations).",
     )
     p_policy.add_argument("--skip-validate", action="store_true", help="Skip base schema/graph/fingerprint validation.")
+    p_policy.add_argument(
+        "--require-memory-for-prod",
+        action="store_true",
+        help="Require production AASUs to explicitly configure memory relationships.",
+    )
     p_policy.set_defaults(func=cmd_policy_check)
 
     p_memory = sub.add_parser(

--- a/tools/aasu_registry.py
+++ b/tools/aasu_registry.py
@@ -62,6 +62,52 @@ def _read_nested(obj: dict[str, Any], path: list[str]) -> Any:
     return cur
 
 
+def _ci_type(obj: dict[str, Any]) -> str | None:
+    spec = obj.get("spec")
+    if not isinstance(spec, dict):
+        return None
+    typ = spec.get("type")
+    return typ if isinstance(typ, str) else None
+
+
+def _is_prod_aasu(obj: dict[str, Any]) -> bool:
+    if _ci_type(obj) != "aasu":
+        return False
+    spec = obj.get("spec")
+    if not isinstance(spec, dict):
+        return False
+    return spec.get("environment") == "prod"
+
+
+def _is_unpinned_version(version: str) -> bool:
+    value = version.strip().lower()
+    return value in {"provider:rolling", "latest", "main", "master"}
+
+
+def _load_assets_and_relationships(
+    registry_dir: Path,
+) -> tuple[dict[str, dict[str, Any]], list[tuple[str, str, str]]]:
+    assets_by_id: dict[str, dict[str, Any]] = {}
+    relationships: list[tuple[str, str, str]] = []
+
+    for _, obj in iter_manifests(registry_dir):
+        kind = obj.get("kind")
+        if kind == "ConfigurationItem":
+            ci_id = _read_nested(obj, ["metadata", "id"])
+            if isinstance(ci_id, str):
+                assets_by_id[ci_id] = obj
+            continue
+
+        if kind == "Relationship":
+            rel_type = _read_nested(obj, ["spec", "type"])
+            from_id = _read_nested(obj, ["spec", "from"])
+            to_id = _read_nested(obj, ["spec", "to"])
+            if isinstance(rel_type, str) and isinstance(from_id, str) and isinstance(to_id, str):
+                relationships.append((rel_type, from_id, to_id))
+
+    return assets_by_id, relationships
+
+
 def _replace_single_occurrence(text: str, old: str, new: str) -> str | None:
     if old == new:
         return text
@@ -301,16 +347,8 @@ def _load_registry_index(registry_dir: Path) -> tuple[dict[str, dict[str, Any]],
     - assets_by_id: CI id -> manifest dict
     - aasu_reverse_refs: asset CI id -> set of AASU CI ids that reference it in (P,M,R,T,K)
     """
-    assets_by_id: dict[str, dict[str, Any]] = {}
+    assets_by_id, relationships = _load_assets_and_relationships(registry_dir)
     aasu_reverse_refs: dict[str, set[str]] = defaultdict(set)
-
-    for _, obj in iter_manifests(registry_dir):
-        if obj.get("kind") != "ConfigurationItem":
-            continue
-        ci_id = _read_nested(obj, ["metadata", "id"])
-        if not isinstance(ci_id, str):
-            continue
-        assets_by_id[ci_id] = obj
 
     for ci_id, obj in assets_by_id.items():
         spec = obj.get("spec") or {}
@@ -334,6 +372,25 @@ def _load_registry_index(registry_dir: Path) -> tuple[dict[str, dict[str, Any]],
             for t in tools:
                 add_ref(t)
 
+    outgoing: dict[str, set[str]] = defaultdict(set)
+    for _, from_id, to_id in relationships:
+        outgoing[from_id].add(to_id)
+
+    for ci_id, obj in assets_by_id.items():
+        if _ci_type(obj) != "aasu":
+            continue
+        visited: set[str] = set()
+        stack = list(outgoing.get(ci_id, set()))
+        while stack:
+            nxt = stack.pop()
+            if nxt in visited:
+                continue
+            visited.add(nxt)
+            aasu_reverse_refs[nxt].add(ci_id)
+            for child in outgoing.get(nxt, set()):
+                if child not in visited:
+                    stack.append(child)
+
     return assets_by_id, aasu_reverse_refs
 
 
@@ -350,6 +407,186 @@ def _format_owner_list(owners: Any) -> list[str]:
         if isinstance(otype, str) and isinstance(oid, str) and isinstance(role, str):
             out.append(f"{otype}:{oid} ({role})")
     return out
+
+
+def _index_relationships(
+    relationships: list[tuple[str, str, str]],
+) -> tuple[dict[str, list[tuple[str, str]]], dict[str, list[tuple[str, str]]]]:
+    outgoing: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    incoming: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for rel_type, from_id, to_id in relationships:
+        outgoing[from_id].append((rel_type, to_id))
+        incoming[to_id].append((rel_type, from_id))
+    return outgoing, incoming
+
+
+def cmd_policy_check(args: argparse.Namespace) -> int:
+    registry_dir = Path(args.registry).resolve()
+    if not args.skip_validate:
+        base_rc = validate_registry_dir(registry_dir)
+        if base_rc != 0:
+            return base_rc
+
+    assets_by_id, relationships = _load_assets_and_relationships(registry_dir)
+    outgoing, incoming = _index_relationships(relationships)
+
+    findings: list[str] = []
+    for ci_id, obj in assets_by_id.items():
+        if not _is_prod_aasu(obj):
+            continue
+
+        snapshot = _read_nested(obj, ["spec", "aasu", "snapshot"])
+        if not isinstance(snapshot, dict):
+            findings.append(f"{ci_id}: missing spec.aasu.snapshot")
+            continue
+
+        def inspect_component(name: str, component: Any) -> None:
+            if not isinstance(component, dict):
+                return
+            version = component.get("version")
+            if isinstance(version, str) and _is_unpinned_version(version):
+                findings.append(f"{ci_id}: component {name} uses unpinned version '{version}'")
+
+        for key in ("P", "M", "R", "K"):
+            inspect_component(key, snapshot.get(key))
+        tools = snapshot.get("T")
+        if isinstance(tools, list):
+            for idx, tool in enumerate(tools):
+                inspect_component(f"T[{idx}]", tool)
+
+        has_attestation = False
+        for rel_type, src in incoming.get(ci_id, []):
+            if rel_type != "attests":
+                continue
+            src_obj = assets_by_id.get(src)
+            if isinstance(src_obj, dict) and _ci_type(src_obj) == "attestation_bundle":
+                has_attestation = True
+                break
+        if not has_attestation:
+            findings.append(f"{ci_id}: missing attestation_bundle -> attests relationship")
+
+        model_component = snapshot.get("M")
+        model_id = model_component.get("asset") if isinstance(model_component, dict) else None
+        if isinstance(model_id, str):
+            model_has_aibom = False
+            for rel_type, src in incoming.get(model_id, []):
+                if rel_type != "attests":
+                    continue
+                src_obj = assets_by_id.get(src)
+                if isinstance(src_obj, dict) and _ci_type(src_obj) == "aibom_document":
+                    model_has_aibom = True
+                    break
+            if not model_has_aibom:
+                findings.append(f"{ci_id}: model '{model_id}' has no incoming attests edge from aibom_document")
+
+        outgoing_rels = outgoing.get(ci_id, [])
+        if not any(rel_type == "uses_short_term_memory" for rel_type, _ in outgoing_rels):
+            findings.append(f"{ci_id}: missing uses_short_term_memory relationship")
+        if not any(rel_type == "uses_long_term_memory" for rel_type, _ in outgoing_rels):
+            findings.append(f"{ci_id}: missing uses_long_term_memory relationship")
+
+    if findings:
+        print("POLICY CHECK FAILED")
+        for finding in findings:
+            print(f"- {finding}")
+        return 1
+
+    print("OK: policy checks passed for production AASUs.")
+    return 0
+
+
+def cmd_memory_audit(args: argparse.Namespace) -> int:
+    registry_dir = Path(args.registry).resolve()
+    if not args.skip_validate:
+        base_rc = validate_registry_dir(registry_dir)
+        if base_rc != 0:
+            return base_rc
+
+    assets_by_id, relationships = _load_assets_and_relationships(registry_dir)
+    outgoing, _ = _index_relationships(relationships)
+    findings: list[str] = []
+
+    print("## Memory Audit")
+    for ci_id, obj in sorted(assets_by_id.items()):
+        if _ci_type(obj) != "aasu":
+            continue
+        rels = outgoing.get(ci_id, [])
+        stm = [dst for rel_type, dst in rels if rel_type == "uses_short_term_memory"]
+        ltm = [dst for rel_type, dst in rels if rel_type == "uses_long_term_memory"]
+        print(f"- `{ci_id}`")
+        print(f"  - short-term memory profiles: {', '.join(stm) if stm else 'none'}")
+        print(f"  - long-term memory profiles: {', '.join(ltm) if ltm else 'none'}")
+
+        if len(stm) != 1:
+            findings.append(f"{ci_id}: expected exactly one short-term memory profile, found {len(stm)}")
+        if _is_prod_aasu(obj) and len(ltm) != 1:
+            findings.append(f"{ci_id}: production AASU expected exactly one long-term memory profile, found {len(ltm)}")
+
+    for ci_id, obj in sorted(assets_by_id.items()):
+        typ = _ci_type(obj)
+        if typ not in {"memory_short_term_profile", "memory_long_term_profile"}:
+            continue
+        stores = [dst for rel_type, dst in outgoing.get(ci_id, []) if rel_type == "stores_memory_in"]
+        print(f"- `{ci_id}` stores memory in: {', '.join(stores) if stores else 'none'}")
+        if not stores:
+            findings.append(f"{ci_id}: missing stores_memory_in relationship")
+
+    if findings:
+        print("")
+        print("MEMORY AUDIT FINDINGS")
+        for finding in findings:
+            print(f"- {finding}")
+        return 1 if args.strict else 0
+
+    print("")
+    print("OK: memory audit passed.")
+    return 0
+
+
+def cmd_attest_verify(args: argparse.Namespace) -> int:
+    registry_dir = Path(args.registry).resolve()
+    if not args.skip_validate:
+        base_rc = validate_registry_dir(registry_dir)
+        if base_rc != 0:
+            return base_rc
+
+    assets_by_id, relationships = _load_assets_and_relationships(registry_dir)
+    outgoing, incoming = _index_relationships(relationships)
+    findings: list[str] = []
+
+    for ci_id, obj in sorted(assets_by_id.items()):
+        if _ci_type(obj) != "attestation_bundle":
+            continue
+        targets = [dst for rel_type, dst in outgoing.get(ci_id, []) if rel_type == "attests"]
+        if not targets:
+            findings.append(f"{ci_id}: attestation_bundle has no outgoing attests relationships")
+
+    for ci_id, obj in sorted(assets_by_id.items()):
+        if not _is_prod_aasu(obj):
+            continue
+        attest_sources = [
+            src
+            for rel_type, src in incoming.get(ci_id, [])
+            if rel_type == "attests" and _ci_type(assets_by_id.get(src, {})) == "attestation_bundle"
+        ]
+        if not attest_sources:
+            findings.append(f"{ci_id}: production AASU has no attestation_bundle attesting it")
+
+    for ci_id, obj in sorted(assets_by_id.items()):
+        if _ci_type(obj) != "aibom_document":
+            continue
+        targets = [dst for rel_type, dst in outgoing.get(ci_id, []) if rel_type == "attests"]
+        if not targets:
+            findings.append(f"{ci_id}: aibom_document has no outgoing attests relationships")
+
+    if findings:
+        print("ATTEST VERIFY FAILED")
+        for finding in findings:
+            print(f"- {finding}")
+        return 1
+
+    print("OK: attestation relationships are present.")
+    return 0
 
 
 def cmd_impact(args: argparse.Namespace) -> int:
@@ -566,6 +803,7 @@ def cmd_impact(args: argparse.Namespace) -> int:
 
         lines.append("### Next steps")
         lines.append("- Run `python3 tools/aasu_registry.py validate`.")
+        lines.append("- Run `python3 tools/aasu_registry.py policy-check` for regulated policy gates.")
         lines.append("- If you changed any AASU snapshot `(P,M,R,T,K)`, run `python3 tools/aasu_registry.py fingerprint --all --write`.")
         out_text = "\n".join(lines).rstrip() + "\n"
 
@@ -615,6 +853,28 @@ def build_parser() -> argparse.ArgumentParser:
     p_impact.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
     p_impact.add_argument("--out", help="Write output to a file instead of stdout.")
     p_impact.set_defaults(func=cmd_impact)
+
+    p_policy = sub.add_parser(
+        "policy-check",
+        help="Run policy checks for regulated-ready AASU governance (pinning, memory links, attestations).",
+    )
+    p_policy.add_argument("--skip-validate", action="store_true", help="Skip base schema/graph/fingerprint validation.")
+    p_policy.set_defaults(func=cmd_policy_check)
+
+    p_memory = sub.add_parser(
+        "memory-audit",
+        help="Summarize AASU short/long-term memory relationships and storage bindings.",
+    )
+    p_memory.add_argument("--skip-validate", action="store_true", help="Skip base schema/graph/fingerprint validation.")
+    p_memory.add_argument("--strict", action="store_true", help="Return non-zero if audit findings exist.")
+    p_memory.set_defaults(func=cmd_memory_audit)
+
+    p_attest = sub.add_parser(
+        "attest-verify",
+        help="Verify attestation bundle and AIBOM attestation relationships are present.",
+    )
+    p_attest.add_argument("--skip-validate", action="store_true", help="Skip base schema/graph/fingerprint validation.")
+    p_attest.set_defaults(func=cmd_attest_verify)
 
     return parser
 

--- a/tools/aasu_registry.py
+++ b/tools/aasu_registry.py
@@ -133,6 +133,8 @@ def update_aasu_fingerprint_in_file(path: Path, *, write: bool) -> tuple[bool, s
     snapshot = _read_nested(obj, ["spec", "aasu", "snapshot"])
     if snapshot is None:
         raise ValueError(f"Missing spec.aasu.snapshot: {path}")
+    if not isinstance(snapshot, dict):
+        raise ValueError(f"Invalid spec.aasu.snapshot (expected object): {path}")
 
     expected = compute_sha256_fingerprint(snapshot)
 
@@ -199,6 +201,10 @@ def cmd_fingerprint(args: argparse.Namespace) -> int:
 
             existing = _read_nested(obj, ["spec", "aasu", "fingerprint", "value"])
             snapshot = _read_nested(obj, ["spec", "aasu", "snapshot"])
+            if snapshot is None:
+                raise ValueError("Missing spec.aasu.snapshot")
+            if not isinstance(snapshot, dict):
+                raise ValueError("Invalid spec.aasu.snapshot (expected object)")
             expected = compute_sha256_fingerprint(snapshot)
 
             if existing != expected:

--- a/tools/validate_registry.py
+++ b/tools/validate_registry.py
@@ -49,6 +49,14 @@ def error(msg: str) -> None:
     print(f"ERROR: {msg}", file=sys.stderr)
 
 
+def _asset_type(obj: dict[str, Any]) -> str | None:
+    spec = obj.get("spec")
+    if not isinstance(spec, dict):
+        return None
+    typ = spec.get("type")
+    return typ if isinstance(typ, str) else None
+
+
 def validate_registry_dir(registry_dir: Path) -> int:
     registry_dir = registry_dir.resolve()
     schemas_dir = registry_dir / "schemas"
@@ -75,7 +83,9 @@ def validate_registry_dir(registry_dir: Path) -> int:
         manifests.append((path, obj))
 
     assets_by_id: dict[str, Path] = {}
+    assets_obj_by_id: dict[str, dict[str, Any]] = {}
     rels_by_id: dict[str, Path] = {}
+    relationships: list[tuple[Path, dict[str, Any]]] = []
     had_errors = False
 
     for path, obj in manifests:
@@ -102,6 +112,7 @@ def validate_registry_dir(registry_dir: Path) -> int:
                     error(f"Duplicate CI id '{ci_id}' in {path} (already in {assets_by_id[ci_id]})")
                 else:
                     assets_by_id[ci_id] = path
+                    assets_obj_by_id[ci_id] = obj
 
             spec = obj.get("spec") or {}
             if spec.get("type") == "aasu":
@@ -129,19 +140,97 @@ def validate_registry_dir(registry_dir: Path) -> int:
                     error(f"Duplicate relationship id '{rel_id}' in {path} (already in {rels_by_id[rel_id]})")
                 else:
                     rels_by_id[rel_id] = path
+            relationships.append((path, obj))
 
-    for path, obj in manifests:
-        if obj.get("kind") != "Relationship":
-            continue
+    relationship_types_expected: dict[str, tuple[set[str], set[str]]] = {
+        "uses_short_term_memory": ({"aasu"}, {"memory_short_term_profile"}),
+        "uses_long_term_memory": ({"aasu"}, {"memory_long_term_profile"}),
+        "uses_skill": ({"aasu"}, {"skill_package"}),
+        "uses_knowledge_graph": ({"aasu"}, {"knowledge_graph"}),
+        "uses_context_graph_profile": ({"aasu"}, {"context_graph_profile"}),
+        "context_graph_derived_from": ({"context_graph_profile"}, {"knowledge_graph"}),
+        "stores_memory_in": (
+            {"memory_short_term_profile", "memory_long_term_profile"},
+            {"store"},
+        ),
+        "indexes_from_corpus": ({"retrieval"}, {"dataset"}),
+        "attests": ({"attestation_bundle", "aibom_document"}, set()),
+    }
+
+    outgoing_by_from: dict[str, list[tuple[str, str, Path]]] = {}
+    for path, obj in relationships:
         spec = obj.get("spec") or {}
         from_id = spec.get("from")
         to_id = spec.get("to")
+        rel_type = spec.get("type")
         if isinstance(from_id, str) and from_id not in assets_by_id:
             had_errors = True
             error(f"Relationship endpoint missing (from='{from_id}') referenced by {path}")
         if isinstance(to_id, str) and to_id not in assets_by_id:
             had_errors = True
             error(f"Relationship endpoint missing (to='{to_id}') referenced by {path}")
+
+        if not (isinstance(from_id, str) and isinstance(to_id, str) and isinstance(rel_type, str)):
+            continue
+
+        outgoing_by_from.setdefault(from_id, []).append((rel_type, to_id, path))
+
+        expected = relationship_types_expected.get(rel_type)
+        if expected is None:
+            continue
+
+        from_types, to_types = expected
+        from_obj = assets_obj_by_id.get(from_id)
+        to_obj = assets_obj_by_id.get(to_id)
+        from_type = _asset_type(from_obj) if isinstance(from_obj, dict) else None
+        to_type = _asset_type(to_obj) if isinstance(to_obj, dict) else None
+
+        if from_types and from_type not in from_types:
+            had_errors = True
+            error(
+                f"Relationship type '{rel_type}' requires from.type in {sorted(from_types)}, "
+                f"got '{from_type}' for {from_id} in {path}"
+            )
+        if to_types and to_type not in to_types:
+            had_errors = True
+            error(
+                f"Relationship type '{rel_type}' requires to.type in {sorted(to_types)}, "
+                f"got '{to_type}' for {to_id} in {path}"
+            )
+
+    for ci_id, ci_obj in assets_obj_by_id.items():
+        if _asset_type(ci_obj) != "aasu":
+            continue
+        spec = ci_obj.get("spec") or {}
+        environment = spec.get("environment")
+        outgoing = outgoing_by_from.get(ci_id, [])
+
+        stm = [r for r in outgoing if r[0] == "uses_short_term_memory"]
+        if len(stm) != 1:
+            had_errors = True
+            error(
+                f"AASU '{ci_id}' must have exactly one uses_short_term_memory relationship; "
+                f"found {len(stm)}"
+            )
+
+        ltm = [r for r in outgoing if r[0] == "uses_long_term_memory"]
+        if environment == "prod" and len(ltm) != 1:
+            had_errors = True
+            error(
+                f"Production AASU '{ci_id}' must have exactly one uses_long_term_memory relationship; "
+                f"found {len(ltm)}"
+            )
+        elif len(ltm) > 1:
+            had_errors = True
+            error(f"AASU '{ci_id}' has multiple uses_long_term_memory relationships ({len(ltm)}).")
+
+        kg = [r for r in outgoing if r[0] == "uses_knowledge_graph"]
+        cg = [r for r in outgoing if r[0] == "uses_context_graph_profile"]
+        if cg and not kg:
+            had_errors = True
+            error(
+                f"AASU '{ci_id}' uses_context_graph_profile but has no uses_knowledge_graph relationship."
+            )
 
     if had_errors:
         return 1

--- a/tools/validate_registry.py
+++ b/tools/validate_registry.py
@@ -206,23 +206,29 @@ def validate_registry_dir(registry_dir: Path) -> int:
         outgoing = outgoing_by_from.get(ci_id, [])
 
         stm = [r for r in outgoing if r[0] == "uses_short_term_memory"]
-        if len(stm) != 1:
+        if len(stm) > 1:
             had_errors = True
             error(
-                f"AASU '{ci_id}' must have exactly one uses_short_term_memory relationship; "
-                f"found {len(stm)}"
+                f"AASU '{ci_id}' has multiple uses_short_term_memory relationships ({len(stm)})."
             )
 
         ltm = [r for r in outgoing if r[0] == "uses_long_term_memory"]
-        if environment == "prod" and len(ltm) != 1:
+        if len(ltm) > 1:
             had_errors = True
             error(
-                f"Production AASU '{ci_id}' must have exactly one uses_long_term_memory relationship; "
-                f"found {len(ltm)}"
+                f"AASU '{ci_id}' has multiple uses_long_term_memory relationships ({len(ltm)})."
             )
-        elif len(ltm) > 1:
+        if ltm and not stm:
             had_errors = True
-            error(f"AASU '{ci_id}' has multiple uses_long_term_memory relationships ({len(ltm)}).")
+            error(
+                f"AASU '{ci_id}' uses long-term memory but is missing uses_short_term_memory relationship."
+            )
+        if environment == "prod" and stm and len(ltm) != 1:
+            had_errors = True
+            error(
+                f"Production AASU '{ci_id}' with memory enabled must have exactly one "
+                f"uses_long_term_memory relationship; found {len(ltm)}"
+            )
 
         kg = [r for r in outgoing if r[0] == "uses_knowledge_graph"]
         cg = [r for r in outgoing if r[0] == "uses_context_graph_profile"]


### PR DESCRIPTION
## Summary
- Add v1alpha2 governance extensions: skills, memory profiles, knowledge/context graphs
- Add AIBOM and attestation assets + relationships
- Extend registry schemas and tooling (policy-check, memory-audit, attest-verify)
- Update docs and examples to reflect new governance model

## Linked issue / ADR
- https://github.com/SAISec/AASU/issues/3

## Reuse justification
- Reused existing registry structure and tooling; extended schemas and examples to cover new governance primitives.

## Migration notes
- None (backward-compatible additions; stricter validation only for new relationships)

## Approvals
- Security Champion / Repo Maintainer: Manoj (approved dev-target PR)

## Validation
- python3 tools/aasu_registry.py validate
- python3 tools/aasu_registry.py policy-check
- python3 tools/aasu_registry.py memory-audit --strict
- python3 tools/aasu_registry.py attest-verify

Co-Authored-By: Oz <oz-agent@warp.dev>